### PR TITLE
v1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-shields-io-badge",
   "description": "An API endpoint for generating minimum and compatible FoundryVTT version badges.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Dean Vigoren (vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/route.ts
+++ b/src/classes/route.ts
@@ -70,7 +70,8 @@ export default class Route{
                 description: '',
                 version: '',
                 author: '',
-                minimumCoreVersion: ''
+                minimumCoreVersion: '',
+
             };
         }
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -55,6 +55,11 @@ export namespace FoundryVTT {
             readme?: string;
             bugs?: string;
             changelog?: string;
+            //World.json Specific properties
+            background?: string;
+            coreVersion?: string;
+            nextSession?: string;
+            systemVersion?: string;
         }
     }
 }

--- a/src/routes/version-badge.ts
+++ b/src/routes/version-badge.ts
@@ -34,6 +34,8 @@ export default class VersionBadge extends Route{
             let min = '', compatible = '';
             if(moduleJson.hasOwnProperty('minimumCoreVersion')){
                 min = moduleJson.minimumCoreVersion.toString().trim();
+            } else if(moduleJson.hasOwnProperty('coreVersion') && moduleJson.coreVersion){
+                min = moduleJson.coreVersion.toString().trim();
             }
             if(moduleJson.hasOwnProperty('compatibleCoreVersion') && moduleJson.compatibleCoreVersion){
                 compatible = moduleJson.compatibleCoreVersion.toString().trim();


### PR DESCRIPTION
For world.json files (users can install predefined worlds) the variable used for foundry version is called coreVersion not minimumCoreVersion. So updated the version badge to recognize this and use the coreVersion if it is available and the minimumCoreVersion is not.

Added a few more variables from the world.json to the json interface that we could be loading.